### PR TITLE
convert deployment to statefulset and add persistent volume

### DIFF
--- a/devops-agent/templates/statefulset.yaml
+++ b/devops-agent/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "devops-agent.fullname" . }}
   labels:
@@ -20,13 +20,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      volumes:
-        - name: dind-storage
-          emptyDir: {}
-        - name: trivy-cache
-          hostPath:
-            path: /var/trivy/Library/Caches
-            type: DirectoryOrCreate
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -77,3 +70,19 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      volumes:
+        - name: trivy-cache
+          hostPath:
+            path: /var/trivy/Library/Caches
+            type: DirectoryOrCreate
+  volumeClaimTemplates:
+  - metadata:
+      name: dind-storage
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete

--- a/devops-agent/values.yaml
+++ b/devops-agent/values.yaml
@@ -54,6 +54,9 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+persistence:
+  size: 40Gi
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Every time when pod gets deleted kubernetes creates new agent with new name which keeps a lot of inavtive agents in aazure devops agent pool. Also using node disk creates evicted pods and consume node disk a lot, to prevent this added persistent volume to agents.